### PR TITLE
SourceClear: fixes for vulnerable libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,13 +17,13 @@
     <dependency>
       <groupId>org.apache.struts</groupId>
       <artifactId>struts2-core</artifactId>
-      <version>2.5.12</version>
+      <version>2.5.17</version>
     </dependency>
 
     <dependency>
       <groupId>org.mindrot</groupId>
       <artifactId>jbcrypt</artifactId>
-      <version>0.3m</version>
+      <version>0.4</version>
     </dependency>
 
     <dependency>
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka_2.11</artifactId>
-      <version>0.9.0.1</version>
+      <version>0.10.2.2</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This pull request was generated by SourceClear to upgrade the following vulnerable libraries:

| Type | Library | From | To | Breaking |
| --- | --- | --- | --- | --- |
| MAVEN | `org.apache.struts:struts2-core` | 2.5.12 | 2.5.17 | No |
| MAVEN | `org.apache.kafka:kafka_2.11` | 0.9.0.1 | 0.10.2.2 | No |
| MAVEN | `org.mindrot:jbcrypt` | 0.3m | 0.4 | Yes |

Note that we only upgrade libraries which have versions without any known vulnerabilities. For more information, please see the corresponding [SourceClear report](https://sca.veracode.com/teams/jppFqP4/scans/7181090).

The **Breaking** column states the likelihood that updating to the recommended library version will cause breaking changes in your code. Please verify that the changes here won't cause issues with your project before merging.

To learn more about this feature, please visit our [Help Center](https://help.veracode.com/reader/hHHR3gv0wYc2WbCclECf_A/root) for documentation.

Note: this pull request was generated because you or someone else with access to this repository granted SourceClear access to submit pull requests.
<!-- srcclr-pr-id-d7e063cdb18d91687e0337753c4e05f1ec0bece0f9f4ab4f371a883c6e783aca -->
